### PR TITLE
don't run CI on pushes to `main`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
 
 defaults:


### PR DESCRIPTION
This isn't necessary to run on `main` as everything human-made should go through the PR process.